### PR TITLE
Fixes button style

### DIFF
--- a/template/index.js
+++ b/template/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import getIt from 'get-it'
 import jsonResponse from 'get-it/lib/middleware/jsonResponse'
 import promise from 'get-it/lib/middleware/promise'
-import Button from 'part:@sanity/components/buttons/default'
+import Button from 'part:@sanity/components/buttons/anchor'
 
 import styles from './Cats.css'
 


### PR DESCRIPTION
The default button style is somehow broken when using in a dashboard widget. When compared to the already build in dashboard widgets the button text line-height is different.